### PR TITLE
Wrap Tasks in quotation marks

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -158,7 +158,7 @@ export class TaskFetch extends OpenAPIRoute {
 
 export class TaskList extends OpenAPIRoute {
   static schema = {
-    tags: [Tasks],
+    tags: ['Tasks'],
     summary: 'List all tasks',
     parameters: {
       page: Query(Int, {


### PR DESCRIPTION
The `TaskList` example were missing quotation marks in the `tags` array.